### PR TITLE
Client backward compatibility.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,3 +57,18 @@ Once domain is joined, you can manage users from interface. From command line, y
 
   # net ads info
 
+Factory reset
+-------------
+
+The "Start DC" procedure from the UI is designed for a single run.  If it fails,
+reinstalling the whole server can be avoided with some bash commands.
+
+The following steps are required to clean up the DC state and prepare it for a
+new provisioning run. ::
+
+    realm leave
+    systemctl stop nsdc sssd
+    rm -vf /var/lib/machines/nsdc/etc/samba/smb.conf
+    find /var/lib/machines/nsdc/var/lib/samba/ -type f | xargs -- rm -vf
+    config setprop sssd Provider none status disabled
+    > /etc/sssd/sssd.conf

--- a/root/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service
+++ b/root/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service
@@ -13,7 +13,12 @@ Environment=REALM=mycompany.local
 Environment=ADMINPASS=Nethesis,1234
 Environment=FWDNS=8.8.4.4
 EnvironmentFile=-/etc/sysconfig/samba-provision
-ExecStart=/usr/bin/samba-tool domain provision "--option=dns forwarder=${FWDNS}" "--domain=${DOMAIN}" "--realm=${REALM}" "--adminpass=${ADMINPASS}" ${OPTIONS} ; /bin/cp -av /var/lib/samba/private/krb5.conf /etc/krb5.conf
+ExecStart=/usr/bin/samba-tool domain provision \
+    "--option=dns forwarder=${FWDNS}" \
+    "--domain=${DOMAIN}" "--realm=${REALM}" \
+    "--adminpass=${ADMINPASS}" ${OPTIONS} \
+    ; /bin/cp -av /var/lib/samba/private/krb5.conf /etc/krb5.conf \
+    ; /bin/sed "--expression=\x24 a\\\n\\\n[global]\\\nldap server require strong auth=no" -i /etc/samba/smb.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restore old server behaviour, disabling SSL strong requirement on LDAP
connections. CVE-2016-2112

Refs NethServer/dev#5067
