### PR TITLE
Wrap systemd-run calls with expect NethServer/dev#5103

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-group-create
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-create
@@ -34,20 +34,14 @@ if(! defined ($groupName)) {
 $groupName =~ s/@.*//;
 
 #Create group 
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group add "$groupName"`;
-
-#die if group output differs from successful output
-$out =~ s/^\s+|\s+$|\s+\n+$//g; 
-if ($out !~ /^Added group/){
-    die $out."\n";
+system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group add "$groupName"; expect "Added group" { exit 0 }; exit 3'));
+if ($? != 0) {
+    die("[ERROR] Group $groupName creation failed\n");
 }
 
-print "Added group \"$groupName\"\n";
-
 #Add members to group 
-while (my $userName = shift){
-    my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$userName"`;
-    if ($out =~ /^Added members to group/) {
-        print "Added user $userName to group \"$groupName\"\n";
-    }
+my $members = join(',', @ARGV);
+system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$members"; expect "Added members" { exit 0 }; exit 3'));
+if ($? != 0) {
+    die("[ERROR] Failed to add members to group $groupName\n");
 }

--- a/root/etc/e-smith/events/actions/nethserver-dc-group-delete
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-delete
@@ -34,11 +34,9 @@ if(! defined ($groupName)) {
 $groupName =~ s/@.*//;
 
 #Delete group 
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group delete "$groupName"`;
+system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group delete "$groupName"; expect "Deleted group" { exit 0 }; exit 3'));
 
 #die if group output differs from successful output
-if ($out !~ /^Deleted group /){
-    die $out."\n";
+if ($? != 0){
+    die("[ERROR] Deletion failed for group $groupName\n");
 }
-
-print "$out";

--- a/root/etc/e-smith/events/actions/nethserver-dc-group-modify
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-modify
@@ -25,6 +25,7 @@ use Errno;
 
 my $event = shift || die "Event name argument is missing\n";
 my $groupName = shift || die "Group name argument is missing\n";
+my $errors = 0;
 
 #accept group@domain format
 $groupName =~ s/@.*//;
@@ -32,7 +33,7 @@ $groupName =~ s/@.*//;
 my @newmembers = @ARGV;
 
 #get group users
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group listmembers "$groupName"`;
+my $out = qx(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group listmembers "$groupName"; expect { exit 0 }');
 
 my @oldmembers = split (" ",$out);
 my @membersToAdd = ();
@@ -60,13 +61,24 @@ foreach my $element (@oldmembers) {
 #remove members
 if (@membersToRemove){
     my $membersToRemove = join (",", @membersToRemove);
-    my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group removemembers "$groupName" "$membersToRemove"`;
-    print $out;
+    system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group removemembers "$groupName" "$membersToRemove"; expect "Removed members" { exit 0}; exit 3'));
+    if($? != 0) {
+        $errors ++;
+    }
 }
 
 #add members
 if (@membersToAdd){
     my $membersToAdd = join (",", @membersToAdd);
-    my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$membersToAdd"`;
-    print $out;
+    system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$membersToAdd"; expect "Added members" { exit 0 }; exit 3'));
+    if($? != 0) {
+        $errors ++;
+    }
 }
+
+if($errors > 0) {
+    warn("[ERROR] Failed to update the members list of group $groupName");
+    exit(1);
+}
+
+exit(0);

--- a/root/etc/e-smith/events/actions/nethserver-dc-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-dc-password-policy
@@ -60,48 +60,22 @@ if ($userName) {
     exit(0);
 }
 
+my $min = 0;
+my $max = 0;
 if($conf{'PassExpires'} ne 'no') {
-    my $min = $conf{"MinPassAge"} || '0';
-    my $max = $conf{"MaxPassAge"} || '180';
-    my $cmd =  "$scmd domain passwordsettings set --min-pwd-age=$min --max-pwd-age=$max";
-    system($cmd);
-    my $out = `$scmd domain passwordsettings show | grep "Minimum password age" | cut -d: -f2`;
-    if ($out !~ /$min/) {
-        warn "[ERROR] Cannot set MinPassAge\n";
-        $errors ++;	    
-    }
-    $out = `$scmd domain passwordsettings show | grep "Maximum password age" | cut -d: -f2`;
-    if ($out !~ /$max/) {
-        warn "[ERROR] Cannot set MaxPassAge\n";
-        $errors ++;	    
-    }
-} else {
-    my $cmd = "$scmd domain passwordsettings set --min-pwd-age=0 --max-pwd-age=0";
-    system($cmd);
-    my $out = `$scmd domain passwordsettings show | grep "Minimum password age" | cut -d: -f2`;
-    if (int($out) > 0) {
-        warn "[ERROR] Cannot disable MinPassAge\n";
-        $errors ++;
-    }
-    $out = `$scmd domain passwordsettings show | grep "Maximum password age" | cut -d: -f2`;
-    if (int($out)) {
-        warn "[ERROR] Cannot disable MaxPassAge\n";
-        $errors ++;
-    }
-
+    $min = $conf{"MinPassAge"} || '0';
+    $max = $conf{"MaxPassAge"} || '180';
 }
+my $domainOpts = qq(--min-pwd-age=$min --max-pwd-age=$max);
 
-my $cmd = '';
 if($conf{'Users'} eq 'strong') {
-    $cmd = "$scmd domain passwordsettings set --complexity=on --history-length=default";
+    $domainOpts .= qq( --complexity=on --history-length=default);
 } else {
-    $cmd = "$scmd domain passwordsettings set --complexity=off --history-length=0";
-}
-my $out = `$cmd`;
-if ($out !~ /All changes applied successfully/) {
-    warn "[ERROR] Cannot set password complexity\n";
-    $errors ++;
+    $domainOpts .= qq( --complexity=off --history-length=0);
 }
 
+system('expect', '-c', qq(spawn -noecho $scmd domain passwordsettings set $domainOpts; expect "All changes applied successfully!" { exit 0 }; exit 3));
+if ($? != 0) {
+    die("[ERROR] Failed to set domain password policy\n");
+}
 
-exit(($errors > 0) ? 1 : 0);

--- a/root/etc/e-smith/events/actions/nethserver-dc-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-dc-password-policy
@@ -47,14 +47,18 @@ my $scmd = "/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool";
 
 if ($userName) {
     my $ldapAccount = (split(/@/,$userName))[0];
+    my $expiryOpts = '';
     if($PassExpires eq 'no') {
-        system("$scmd user setexpiry $ldapAccount --noexpiry");
+        $expiryOpts = '--noexpiry';
     } elsif($PassExpires eq 'yes') {
-        my $max = $conf{"MaxPassAge"} || '180';
-        system("$scmd user setexpiry $ldapAccount --days=$max");
+        $expiryOpts = '--days=' . ($conf{"MaxPassAge"} || '180');
     }
-    exit($?);
-} 
+    system('expect', '-c', qq(spawn -noecho $scmd user setexpiry $ldapAccount $expiryOpts; expect "Expiry for user '$ldapAccount'" { exit 0 }; exit 3));
+    if ($? != 0) {
+        die("[ERROR] Faild to set expiry on user $userName\n");
+    }
+    exit(0);
+}
 
 if($conf{'PassExpires'} ne 'no') {
     my $min = $conf{"MinPassAge"} || '0';

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-create
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-create
@@ -48,14 +48,8 @@ if ($FullName eq '') {
 $userName =~ s/@.*//;
 
 #Create user
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user add "$userName" --random-password --must-change-at-next-login --login-shell=$shell --unix-home=$homeDirPrefix$userName --given-name="$FullName" --use-username-as-cn` ;
-
-$out =~ s/^\s+|\s+$|\s+\n+$//g; 
-
-if (! $out eq "User '$userName' created successfully"){
-    die $out;
+system('expect', '-c', qq(spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user add "$userName" --random-password --must-change-at-next-login "--login-shell=$shell" "--unix-home=$homeDirPrefix$userName" "--given-name=$FullName" --use-username-as-cn; expect "User '$userName' created successfully" { exit 0 }; exit 3));
+if ($? != 0) {
+    die("[ERROR] User $userName creation failed\n");
 }
 
-print $out."\n";
-
-exit 0;

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-delete
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-delete
@@ -34,12 +34,8 @@ if(! defined ($userName)) {
 $userName =~ s/@.*//;
 
 #Delete user
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user delete "$userName"` ;
-
-$out =~ s/^\s+|\s+$|\s+\n+$//g; 
-
-if (! $out eq "Deleted user $userName"){
-    die $out;
+system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user delete "$userName"; expect "Deleted user $userName" { exit 0 }; exit 3'));
+if ($? != 0) {
+    die("[ERROR] User $userName deletion failed\n");
 }
 
-print $out."\n";

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-modify
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-modify
@@ -35,12 +35,8 @@ if(! defined ($userName)) {
 $userName =~ s/@.*//;
 
 #Modify user FullName
-my $out = `/usr/bin/systemd-run -M nsdc -q -t /usr/bin/pdbedit -u "$userName" --fullname="$FullName"` ;
-
-$out =~ s/^\s+|\s+$|\s+\n+$//g; 
-
-if ( $out !~ /Logon/){
-    die $out;
+system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/pdbedit -u "$userName" "--fullname=$FullName"; expect "Unix username:" { exit 0 }; exit 3' >/dev/null));
+if ($? != 0) {
+    die("[ERROR] User $userName modification failed\n");
 }
 
-print "User $userName modified"."\n";

--- a/root/etc/nethserver/todos.d/40nethserver-dc
+++ b/root/etc/nethserver/todos.d/40nethserver-dc
@@ -40,8 +40,8 @@ if($provider eq 'none') {
     };
 
 } elsif($provider eq 'ad') {
-    my $out = qx(exec </dev/null; /usr/bin/systemd-run -M nsdc -q -t /usr/bin/pdbedit -w administrator);
-    if($out =~ m/:4EC38072B9C2D6CBD7467FF62128AEC2:/) {
+    system("expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/pdbedit -w administrator; expect :4EC38072B9C2D6CBD7467FF62128AEC2: { exit 0 }; exit 3' >/dev/null");
+    if($? == 0) {
         $response = {
             'action' => {
                 'label' => __("Set Administrator's password"),


### PR DESCRIPTION
All `systemd-run` calls are wrapped with expect to prevent PTY allocation failures. Wherever possible, I check the command output from expect and set the exit code accordingly.

To properly cover the code changes, re-test the following use cases:
- user creation/modification/deletion
- group creation/modification/deletion
- user password policy change
- domain password policy change
- admin-todo reminder on Dashboard for Administrator's password

NethServer/dev#5103
