### PR TITLE
samba-provision template: don't rely on Provider prop

### DIFF
--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/sysconfig/samba-provision/00workgroup
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/sysconfig/samba-provision/00workgroup
@@ -6,7 +6,7 @@
     $workgroup = 'WORKGROUP';
     if(defined $smb{'Workgroup'} && $smb{'Workgroup'}) {
         $workgroup = $smb{'Workgroup'};
-    } elsif($sssd{'Provider'} eq 'ad') {
+    } else {
         $workgroup = uc((split('\.', $DomainName))[0]);
     }
     $workgroup = substr($workgroup, 0, 15);


### PR DESCRIPTION
We can't rely on `Provider` prop, since the value is updated only at the end of the provisioning process.

NethServer/dev#5116
