### PR TITLE
Forbid simple binds on Samba LDAP without SSL NethServer/dev#5161

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-fix5067
+++ b/root/etc/e-smith/events/actions/nethserver-dc-fix5067
@@ -28,10 +28,10 @@ if ! [[ -f "${cfg}" ]]; then
     exit 0
 fi
 
-if grep -s -F 'ldap server require strong auth=no' "${cfg}"; then
+if ! grep -s -F 'ldap server require strong auth=no' "${cfg}"; then
     exit 0
 fi
 
-echo "[NOTICE] Apply bugfix #5067 and restart nsdc"
-sed $'$ a\\\n[global]\\\nldap server require strong auth=no' -i "${cfg}"
-systemctl try-restart nsdc
+echo "[NOTICE] Revert bugfix #5067. We no longer need it. Restart nsdc to take it into effect."
+sed '/ldap server require strong auth=no/ d' -i "${cfg}"
+

--- a/root/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service
+++ b/root/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service
@@ -17,8 +17,7 @@ ExecStart=/usr/bin/samba-tool domain provision \
     "--option=dns forwarder=${FWDNS}" \
     "--domain=${DOMAIN}" "--realm=${REALM}" \
     "--adminpass=${ADMINPASS}" ${OPTIONS} \
-    ; /bin/cp -av /var/lib/samba/private/krb5.conf /etc/krb5.conf \
-    ; /bin/sed "--expression=\x24 a\\\n\\\n[global]\\\nldap server require strong auth=no" -i /etc/samba/smb.conf
+    ; /bin/cp -av /var/lib/samba/private/krb5.conf /etc/krb5.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Reverts the bugfix 5067 effects and restores the default Samba
configuration that reflects the Microsoft AD behavior.

NethServer/dev#5161