### PR TITLE
Fix restore on clean machine NethServer/dev#5188

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -55,7 +55,7 @@ event_services('nethserver-dc-save', qw(
 event_link("nethserver-dc-pre-backup" , "pre-backup-config", "40");
 event_link("nethserver-dc-post-backup", "post-backup-config", "40");
 event_link("nethserver-dc-pre-restore", "pre-restore-config", "40");
-event_link("nethserver-dc-post-restore", "post-restore-config", "40");
+event_link("nethserver-dc-post-restore", "post-restore-config", "50");
 
 #--------------------------------------------------
 # actions for user-create

--- a/root/etc/e-smith/events/actions/nethserver-dc-join
+++ b/root/etc/e-smith/events/actions/nethserver-dc-join
@@ -21,6 +21,8 @@
 #
 
 ipAddress=$(/sbin/e-smith/config getprop nsdc IpAddress)
+tmp=$(mktemp)
+domain=$(hostname -d)
 
 /sbin/e-smith/config setprop sssd status enabled Provider ad AdDns ${ipAddress}
 /sbin/e-smith/expand-template /etc/dnsmasq.conf
@@ -31,6 +33,20 @@ systemctl stop sssd
 
 # Truncate sssd.conf
 > /etc/sssd/sssd.conf
+
+# Reset administrator password (usefull when restoring a backup)
+echo "Nethesis,1234" > $tmp
+for ((attempt = 1;attempt < 4; attempt++)); do
+    /etc/e-smith/events/actions/nethserver-dc-password-set install "administrator@"$domain $tmp
+    if [[ $? -gt 0 ]]; then
+        echo "[WARNING] Administrator reset password attempt $attempt of 3 failed! Wait a few seconds..."
+    else
+        break
+    fi
+    sleep 5
+done
+rm -f $tmp
+
 
 for ((attempt = 1;attempt < 4; attempt++)); do
     # Join the domain with default credentials

--- a/root/etc/e-smith/events/actions/nethserver-dc-post-restore
+++ b/root/etc/e-smith/events/actions/nethserver-dc-post-restore
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
-# Copyright (C) 2013 Nethesis S.r.l.
-# http://www.nethesis.it - support@nethesis.it
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.netheserver.org
 # 
 # This script is part of NethServer.
 # 
@@ -20,7 +19,16 @@
 # along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Cleanup current configuration
 /etc/e-smith/events/actions/nethserver-sssd-leave
 
+# Restore Samba backups
 find /var/lib/machines/nsdc/var/lib/samba -type f -name '*.[l,t]db.bak' -print0 | while read -d $'\0' f ; do mv -f "$f" "${f%.bak}" ; done
+
+# Install the container
 signal-event nethserver-dc-save
+
+# Lock the administrator account after password reset
+DOMAIN=$(hostname -d)
+/etc/e-smith/events/actions/nethserver-dc-user-lock post-restore-config "administrator@$DOMAIN"
+

--- a/root/etc/e-smith/events/actions/nethserver-dc-post-restore
+++ b/root/etc/e-smith/events/actions/nethserver-dc-post-restore
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2017 Nethesis S.r.l.
-# http://www.netheserver.org
+# http://www.nethesis.it - nethserver@nethesis.it
 # 
 # This script is part of NethServer.
 # 

--- a/root/etc/e-smith/events/actions/nethserver-dc-post-restore
+++ b/root/etc/e-smith/events/actions/nethserver-dc-post-restore
@@ -20,5 +20,7 @@
 # along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+/etc/e-smith/events/actions/nethserver-sssd-leave
+
 find /var/lib/machines/nsdc/var/lib/samba -type f -name '*.[l,t]db.bak' -print0 | while read -d $'\0' f ; do mv -f "$f" "${f%.bak}" ; done
 signal-event nethserver-dc-save


### PR DESCRIPTION
During the restore, the administrator password will be reset to `Nethesis,1234`.
At the end, the account will be locked as in new installation.

In nethserver-testing:
- nethserver-dc-1.1.0-1.6.g987c13f.ns7.x86_64.rpm

NethServer/dev#5188