### PR TITLE
Avoid nethserver-dc-save event in restore config

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -63,6 +63,10 @@ event_actions('post-restore-config', qw(
 ));
 event_templates('post-restore-config', @templates);
 
+event_services('interface-update', qw(
+    nsdc start
+));
+
 #--------------------------------------------------
 # actions for user-create
 #--------------------------------------------------

--- a/createlinks
+++ b/createlinks
@@ -37,7 +37,7 @@ event_actions('nethserver-dc-save', qw(
    nethserver-dc-createadmins 98
 ));
 
-event_templates('nethserver-dc-save', qw(
+my @templates = (qw(
    /var/lib/machines/nsdc/etc/systemd/network/green.network
    /var/lib/machines/nsdc/etc/hostname
    /var/lib/machines/nsdc/etc/hosts
@@ -45,6 +45,8 @@ event_templates('nethserver-dc-save', qw(
    /var/lib/machines/nsdc/etc/sysconfig/samba-provision
    /etc/sysconfig/nsdc
 ));
+
+event_templates('nethserver-dc-save', @templates);
 
 event_services('nethserver-dc-save', qw(
    nsdc restart
@@ -55,7 +57,11 @@ event_services('nethserver-dc-save', qw(
 event_link("nethserver-dc-pre-backup" , "pre-backup-config", "40");
 event_link("nethserver-dc-post-backup", "post-backup-config", "40");
 event_link("nethserver-dc-pre-restore", "pre-restore-config", "40");
-event_link("nethserver-dc-post-restore", "post-restore-config", "50");
+event_actions('post-restore-config', qw(
+    nethserver-dc-install 01
+    nethserver-dc-post-restore 40
+));
+event_templates('post-restore-config', @templates);
 
 #--------------------------------------------------
 # actions for user-create

--- a/root/etc/e-smith/events/actions/nethserver-dc-join
+++ b/root/etc/e-smith/events/actions/nethserver-dc-join
@@ -21,8 +21,6 @@
 #
 
 ipAddress=$(/sbin/e-smith/config getprop nsdc IpAddress)
-tmp=$(mktemp)
-domain=$(hostname -d)
 
 /sbin/e-smith/config setprop sssd status enabled Provider ad AdDns ${ipAddress}
 /sbin/e-smith/expand-template /etc/dnsmasq.conf
@@ -33,20 +31,6 @@ systemctl stop sssd
 
 # Truncate sssd.conf
 > /etc/sssd/sssd.conf
-
-# Reset administrator password (usefull when restoring a backup)
-echo "Nethesis,1234" > $tmp
-for ((attempt = 1;attempt < 4; attempt++)); do
-    /etc/e-smith/events/actions/nethserver-dc-password-set install "administrator@"$domain $tmp
-    if [[ $? -gt 0 ]]; then
-        echo "[WARNING] Administrator reset password attempt $attempt of 3 failed! Wait a few seconds..."
-    else
-        break
-    fi
-    sleep 5
-done
-rm -f $tmp
-
 
 for ((attempt = 1;attempt < 4; attempt++)); do
     # Join the domain with default credentials

--- a/root/etc/e-smith/events/actions/nethserver-dc-post-restore
+++ b/root/etc/e-smith/events/actions/nethserver-dc-post-restore
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 #
 # Copyright (C) 2017 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
@@ -19,16 +20,4 @@
 # along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Cleanup current configuration
-/etc/e-smith/events/actions/nethserver-sssd-leave
-
-# Restore Samba backups
 find /var/lib/machines/nsdc/var/lib/samba -type f -name '*.[l,t]db.bak' -print0 | while read -d $'\0' f ; do mv -f "$f" "${f%.bak}" ; done
-
-# Install the container
-signal-event nethserver-dc-save
-
-# Lock the administrator account after password reset
-DOMAIN=$(hostname -d)
-/etc/e-smith/events/actions/nethserver-dc-user-lock post-restore-config "administrator@$DOMAIN"
-

--- a/root/usr/lib/systemd/system/nsdc.service
+++ b/root/usr/lib/systemd/system/nsdc.service
@@ -6,6 +6,7 @@ Before=machines.target
 Before=sssd.service
 After=network.service
 Wants=network.service
+ConditionPathExists=!/var/run/.nethserver-fixnetwork
 
 [Service]
 Environment=OPTIONS=


### PR DESCRIPTION
Now nethserver-backup-config installs missing packages, restores
configurations then triggers system-adjust action.

NethServer/dev#5188

Reverts PR #31

Revert "restore: lock administrator user after password reset"

This reverts commit 987c13f26231e06c6cecc8a2c749ea71283636b6.

Revert "restore: move nethserver-dc-pre-backup after samba action"

This reverts commit 5d2a9905bb331e0698c491fbd07a1e6f6b742797.

Revert "restore-config: leave domain before re-join"

This reverts commit 022591b7a991901238ec2670f7662d4029e3d7fd.

Revert "nethserver-dc-join: always reset administrator password"

This reverts commit 0a518581cb3e5cfe5b28cd077bc1ffb6cb85d22c.