### PR TITLE
Disable nsdc unit until chroot is initialized

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -29,8 +29,8 @@ event_actions('nethserver-dc-update', qw(
 ));
 
 event_actions('nethserver-dc-save', qw(
-   nethserver-dc-install 01
-   nethserver-dc-create-bridge 02
+   nethserver-dc-create-bridge 01
+   nethserver-dc-install 02
    nethserver-dc-waitstart 95
    nethserver-dc-join 96
    nethserver-dc-password-policy 97

--- a/root/usr/lib/systemd/system/nsdc.service
+++ b/root/usr/lib/systemd/system/nsdc.service
@@ -7,6 +7,7 @@ Before=sssd.service
 After=network.service
 Wants=network.service
 ConditionPathExists=!/var/run/.nethserver-fixnetwork
+ConditionPathExists=/var/lib/machines/nsdc/etc/centos-release
 
 [Service]
 Environment=OPTIONS=


### PR DESCRIPTION
This fix prevents nsdc to be started by adjust-services during nethserver-dc-create-bridge action.

NethServer/dev#5220