### PR TITLE
Add bind-utils RPM to nsdc chroot

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -26,6 +26,7 @@ use esmith::Build::CreateLinks  qw(:all);
 event_actions('nethserver-dc-update', qw(
    initialize-default-databases 00
    nethserver-dc-fix5067 30
+   nethserver-dc-fixchroot 40
 ));
 
 event_actions('nethserver-dc-save', qw(

--- a/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
+++ b/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2016 Nethesis S.r.l.
+# Copyright (C) 2017 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -20,24 +20,15 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-set -e -o pipefail
+provider=$(/sbin/e-smith/config getprop sssd Provider)
+
+if [[ "${provider}" != "ad" ]]; then
+    exit 0
+fi
 
 nsroot=/var/lib/machines/nsdc
 
-function cleanup ()
-{
-    rm -rf ${nsroot}
-    exit 1
-}
-
-if [[ ! -x ${nsroot}/usr/sbin/samba ]]; then
-    trap cleanup ERR
-    mkdir -p ${nsroot}/etc/yum/vars
-    mkdir -p ${nsroot}/var/log/journal
-    mkdir -p ${nsroot}/etc/systemd/network
-    cp -f /etc/yum/vars/* ${nsroot}/etc/yum/vars
-    rpm --root=${nsroot} --import /etc/pki/rpm-gpg/*
-    yum -y --releasever=/ --installroot=${nsroot} install /usr/lib/nethserver-dc/ns-samba-*.ns7.x86_64.rpm centos-release systemd-networkd bind-utils | /usr/libexec/nethserver/ptrack-nsdc-install
-    rm -f ${nsroot}/etc/krb5.conf
-    systemctl enable machines.target
+if ! rpm -q --root=${nsroot} bind-utils >/dev/null; then
+    echo "[NOTICE] Fixing nsdc chroot, by installing missing packages"
+    yum -y --releasever=/ --installroot=${nsroot} install bind-utils | /usr/libexec/nethserver/ptrack-nsdc-install
 fi


### PR DESCRIPTION
It seems the ``samba_dnsupdate`` command wants to execute ``nsupdate``, which come with ``bind-utils``.

As result, the ``samba_dnsupdate`` fails and the workaround is installing ``bind-utils`` manually.

This fix adds bind-utils to nsdc chroot (both existing and fresh installs).

See also:

http://community.nethserver.org/t/cant-change-ad-ip-address/5674/27
