### PR TITLE
Fix nsdc root directory permissions

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
+++ b/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
@@ -44,5 +44,5 @@ fi
 # Set ntpd permissions
 uid=$(grep ntp ${nsroot}/etc/passwd | awk -F: '{print $3}')
 chown 0:$uid ${nsroot}/var/lib/samba/ntp_signd/
-chmod 750 ${nsroot} ${nsroot}/var/lib/samba/ntp_signd/
+chmod 750 ${nsroot}/var/lib/samba/ntp_signd/
 


### PR DESCRIPTION
This should avoid networkd error:
```
SYSTEMD_LOG_LEVEL=debug /usr/lib/systemd/systemd-networkd
        name_to_handle_at on /dev: Permission denied
        the udev service seems not to be active, disable the monitor
        Could not connect to bus: Permission denied
```

NethServer/dev#5253