### PR TITLE
Legacy devices NTLM auth compatibility

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-migrate
+++ b/root/etc/e-smith/events/actions/nethserver-dc-migrate
@@ -102,6 +102,7 @@ EOF
 
 if [[ $? == 0 ]]; then
     /etc/e-smith/events/actions/nethserver-dc-fixinclude ${event}
+    echo -e '\n# enable legacy devices support (badlock vulnerability):\nntlm auth = yes' >> ${destDir}/etc/samba/smb.conf
 else
     rm -f ${destDir}/etc/samba/smb.conf
 fi

--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service/20service
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service/20service
@@ -19,6 +19,7 @@ EOF1
         $OUT = <<'EOF2'
 ExecStart=/usr/bin/samba-tool domain classicupgrade \
     "--option=include = /etc/samba/smb.conf.include" \
+    "--option=ntlm auth = yes" \
     "--realm=${REALM}" \
     --dbdir=/srv /srv/smb.ns6upgrade.conf \
     ; /usr/bin/samba-tool user setpassword administrator "--newpassword=${ADMINPASS}" \


### PR DESCRIPTION
Apply the old default value for ntlm auth, changed by badlock fix.

See http://badlock.org/

NethServer/dev#5289