### PR TITLE
Fix DC gateway configuration for routers

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-condrestart
+++ b/root/etc/e-smith/events/actions/nethserver-dc-condrestart
@@ -20,24 +20,35 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-target=/var/lib/machines/nsdc/etc/samba/smb.conf.include
+targets="\
+    /var/lib/machines/nsdc/etc/samba/smb.conf.include \
+    /var/lib/machines/nsdc/etc/systemd/network/green.network \
+"
+
+needRestart=0
 status=$(/sbin/e-smith/config getprop nsdc status)
 
 if [[ "${status}" != "enabled" ]]; then
     exit 0
 fi
 
-if [[ ! -f ${target} ]]; then
-    exit 0
-fi
+for target in ${targets}; do
 
-/sbin/e-smith/expand-template ${target}
+    if [[ ! -f ${target} ]]; then
+        continue
+    fi
 
-# Compare modify and change unix timestamps. Restart samba nsdc when the
-# expanded file contents have changed.  See also esmith::templates Perl module.
-if eval $(stat --printf='(( %Y == %Z ))' ${target}); then
+    /sbin/e-smith/expand-template ${target}
+
+    # Compare modify and change unix timestamps. Restart samba nsdc when the
+    # expanded file contents have changed.  See also esmith::templates Perl module.
+    if eval $(stat --printf='(( %Y == %Z ))' ${target}); then
+        echo "[NOTICE] ${target} has changed"
+        ((needRestart++))
+    fi
+done
+
+if (($needRestart > 0)); then
     echo "[NOTICE] nsdc Samba configuration changed. Restarting Samba Domain Controller..."
-    systemctl -M nsdc try-restart samba
+    systemctl try-restart nsdc
 fi
-
-

--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/network/green.network/10base
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/network/green.network/10base
@@ -10,11 +10,14 @@ Name=host0
     $OUT = "[Network]\n";
     $OUT .= "Address=" . $nsdc{'IpAddress'} . '/' . ipv4_msk2cidr($ndb->get_prop($bridge, 'netmask')). "\n\n";
 
-    $gateway=$ndb->get_prop($bridge, 'gateway');
-    if($gateway) {
-        $OUT .= "[Route]\n";
-        $OUT .= "Gateway=$gateway\n";
+    my $gateway = $ndb->get_prop($bridge, 'gateway');
+    if(!$gateway || scalar $ndb->red()) {
+        # if the gateway is defined on a different network/interface, set our green IP:
+        $gateway = $ndb->get_prop($bridge, 'ipaddr');
     }
+    
+    $OUT .= "[Route]\n";
+    $OUT .= "Gateway=$gateway\n";
 }
 
 


### PR DESCRIPTION
If a red interface is present, assume we are the network gateway and
adjust nsdc network configuration accordingly.

NethServer/dev#5321