### PR TITLE
Fix action failures during restore-config

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
+++ b/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
@@ -21,12 +21,12 @@
 #
 
 provider=$(/sbin/e-smith/config getprop sssd Provider)
+nsroot=/var/lib/machines/nsdc
 
 if [[ "${provider}" != "ad" ]]; then
     exit 0
 fi
 
-nsroot=/var/lib/machines/nsdc
 
 for package in bind-utils ntp
 do
@@ -46,3 +46,4 @@ uid=$(grep ntp ${nsroot}/etc/passwd | awk -F: '{print $3}')
 chown 0:$uid ${nsroot}/var/lib/samba/ntp_signd/
 chmod 750 ${nsroot}/var/lib/samba/ntp_signd/
 
+exit 0


### PR DESCRIPTION
Fix action failures during restore-config

```
Feb 28 16:55:39 vm5 esmith::event[3940]: chown: cannot access ‘/var/lib/machines/nsdc/var/lib/samba/ntp_s
ignd/’: No such file or directory
Feb 28 16:55:39 vm5 esmith::event[3940]: chmod: cannot access ‘/var/lib/machines/nsdc/var/lib/samba/ntp_s
ignd/’: No such file or directory
Feb 28 16:55:39 vm5 esmith::event[3940]: Action: /etc/e-smith/events/nethserver-dc-update/S40nethserver-dc-fixchroot FAILED: 1 [1.543933]
```

NethServer/dev#5428