### PR TITLE
Force Samba and SSSD to use the local AD DC

### DIFF
--- a/root/etc/e-smith/templates/etc/samba/smb.conf/10password_server
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/10password_server
@@ -1,0 +1,5 @@
+#
+# 10password_server
+#
+password_server = { $nsdc{'IpAddress'} }
+

--- a/root/etc/e-smith/templates/etc/sssd/sssd.conf/02provider_config_localad
+++ b/root/etc/e-smith/templates/etc/sssd/sssd.conf/02provider_config_localad
@@ -1,0 +1,7 @@
+{
+    #
+    # 02provider_config_localad
+    #
+    $provider_config .= "ad_server = $nsdc{'IpAddress'}\n";
+    '';
+}


### PR DESCRIPTION
This setting ensures we do not rely on auto discovery to find a DC. The
local DC is forcibly selected.