### PR TITLE
 Replace systemd-run with nsdc-run 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,33 @@ nethserver-dc-save event
 
 Realmd writes a lot of information on the system journal. See `journalctl` command. 
 
-To have a shell inside the ``nsdc`` container, you can run ::
+Running commands in ``nsdc``
+----------------------------
+
+To get a shell inside the ``nsdc`` container, you can run ::
 
  # systemd-run -M nsdc -t /bin/bash
+
+As alternative, run a specific command in the container with the ``nsdc-run``
+helper: ::
+
+ # nsdc-run cat /etc/hostname
+
+The ``--`` string helps to separate the argument list: ::
+
+ # nsdc-run -- ls --help
+
+For more information: ::
+
+ # nsdc-run --help
+
+Always make sure to close interactive sessions to avoid errors like: ::
+
+  Failed to get machine PTY: No such file or directory
+
+To get a list of sessions run ::
+
+  loginctl
 
 
 Manual Join
@@ -95,7 +119,7 @@ Factory reset
 -------------
 
 The "Start DC" procedure from the "Accounts provider" page is designed for a
-single run.  If it fails, reinstalling the whole server can be avoided by
+single run.  If it fails, re-installing the whole server can be avoided by
 running the following command ::
 
     signal-event nethserver-dc-factory-reset
@@ -103,7 +127,7 @@ running the following command ::
 The command cleans up the DC state and prepare it for new provisioning run.
 **Any existing user and group account is erased**.
 
-If a full DC reinstall is desired, after factory reset event, run also ::
+If a full DC re-install is desired, after factory reset event, run also ::
 
     rm -rf /var/lib/machines/nsdc
 
@@ -114,7 +138,7 @@ Execute: ::
 
   signal-event nethserver-sssd-remove-provider
 
-Upgrade the containter
+Upgrade the container
 ----------------------
 
 The upgrade procedure will:
@@ -137,7 +161,7 @@ Changing the IP address of DC
     Before applying this procedure, read carefully the `official Samba wiki page
     <https://wiki.samba.org/index.php/Changing_the_IP_Address_of_a_Samba_AD_DC>`_.
 
-The IP address of nsdc containter must be in the same network of the bridged green interface.
+The IP address of nsdc container must be in the same network of the bridged green interface.
 If needed, first change the address of the green interface, then proceed with the following.
 
 Example, change the network address:
@@ -161,7 +185,7 @@ Alternate UPN suffix
 --------------------
 
 The default UPN (User Principal Name) suffix for a user account is the SSSD realm, but
-the nsdc containter is configured to use also an extra UPN suffix set
+the nsdc container is configured to use also an extra UPN suffix set
 to the FQDN of the host machine.
 
 Example:

--- a/createlinks
+++ b/createlinks
@@ -55,6 +55,8 @@ my @templates = (qw(
    /var/lib/machines/nsdc/etc/resolv.conf
    /var/lib/machines/nsdc/etc/ntp.conf
    /var/lib/machines/nsdc/etc/systemd/system/samba-provision.service
+   /var/lib/machines/nsdc/etc/systemd/system/nsdc-run@.service
+   /var/lib/machines/nsdc/etc/systemd/system/nsdc-run.socket
    /var/lib/machines/nsdc/srv/smb.ns6upgrade.conf
    /var/lib/machines/nsdc/srv/post-provision.sh
    /etc/sysconfig/nsdc

--- a/nethserver-dc.spec
+++ b/nethserver-dc.spec
@@ -12,7 +12,6 @@ BuildRequires:  nethserver-devtools
 BuildRequires:  systemd
 
 Requires: nethserver-sssd > 1.1.9-1.ns7
-Requires: expect
 Requires: rsync
 Requires(post): systemd
 Requires(preun): systemd

--- a/root/etc/e-smith/events/actions/nethserver-dc-autoupdate
+++ b/root/etc/e-smith/events/actions/nethserver-dc-autoupdate
@@ -21,8 +21,10 @@
 #
 
 status=$(/sbin/e-smith/config getprop nsdc status)
+nsroot=/var/lib/machines/nsdc
 
-if [[ "${status}" == "disabled" ]]; then
+# Skip this action if nsdc is not installed at all (first install)
+if [[ ! -x ${nsroot}/usr/sbin/samba || "${status}" == "disabled" ]]; then
     exit 0
 fi
 
@@ -33,7 +35,7 @@ if [[ "${current}" != "${available}" && "${newer}" == "${available}" ]]; then
     echo "[NOTICE] Upgrade ns-samba version $available"
     /sbin/e-smith/signal-event nethserver-dc-upgrade
     exit $?
-elif [[ ! -x /var/lib/machines/nsdc/usr/libexec/nsdc-run-worker ]]; then
+elif [[ ! -x ${nsroot}/usr/libexec/nsdc-run-worker ]]; then
     echo "[NOTICE] Configure and start the nsdc-run service for the first time"
     /sbin/e-smith/signal-event nethserver-dc-upgrade
     exit $?

--- a/root/etc/e-smith/events/actions/nethserver-dc-autoupdate
+++ b/root/etc/e-smith/events/actions/nethserver-dc-autoupdate
@@ -33,6 +33,10 @@ if [[ "${current}" != "${available}" && "${newer}" == "${available}" ]]; then
     echo "[NOTICE] Upgrade ns-samba version $available"
     /sbin/e-smith/signal-event nethserver-dc-upgrade
     exit $?
+elif [[ ! -x /var/lib/machines/nsdc/usr/libexec/nsdc-run-worker ]]; then
+    echo "[NOTICE] Configure and start the nsdc-run service for the first time"
+    /sbin/e-smith/signal-event nethserver-dc-upgrade
+    exit $?
 fi
 
 exit 0

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -80,7 +80,7 @@ EOF
 
 # Update DNS records
 for((a=0; a < 60; a++)); do
-    systemd-run -q -t -M nsdc /usr/sbin/samba_dnsupdate --verbose | grep -q 'No DNS updates needed'
+    nsdc-run -e -- /usr/sbin/samba_dnsupdate --verbose | grep -q 'No DNS updates needed'
     if [ $? -eq 0 ]; then
        break
     fi

--- a/root/etc/e-smith/events/actions/nethserver-dc-createadmins
+++ b/root/etc/e-smith/events/actions/nethserver-dc-createadmins
@@ -36,13 +36,7 @@ fi
 /etc/e-smith/events/actions/nethserver-dc-user-lock $EVENT "$ADMIN@$DOMAIN"
 
 # add the admin account to Domain Admins group
-expect <<EOF
-spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "Domain Admins" "$ADMIN"
-expect "Added members" { exit 0 }
-exit 3
-EOF
-
-
+nsdc-run -e -- /usr/bin/samba-tool group addmembers "Domain Admins" "$ADMIN"
 
 # Lock the administrator account
 /etc/e-smith/events/actions/nethserver-dc-user-lock $EVENT "administrator@$DOMAIN"

--- a/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
+++ b/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
@@ -93,47 +93,7 @@ EOF
 # Generate (if it does not already exist) and store the ldapservice password
 perl -MNethServer::Password -e "print NethServer::Password::store(\"ldapservice\")" > ${tmp_secret}
 
-function systemd_run_sync()
-{
-  local unit_name attempts 
-  # systemd properties
-  local ExecMainStatus MainPID
-  ExecMainStatus=3
-  unit_name=$(mktemp -u -d create-ldapservice-XXXXXX)
-
-  systemd-run --unit=${unit_name} --remain-after-exit -M nsdc "$@"
-  if [[ $? != 0 ]]; then
-    echo "[ERROR] failed to spawn ${unit_name}"
-    return 6
-  fi
-
-  # Wait until the unit is considered active:
-  while ! systemctl is-active -q -M nsdc ${unit_name}; do
-    if ((++attempts > 5 )); then
-      echo "[ERROR] cannot find the ${unit_name} active task"
-      return 2
-    fi
-    sleep 1
-  done
-
-  # Poll the unit exit code
-  attempts=0
-  while eval $(systemctl show -M nsdc ${unit_name} -p ExecMainStatus -p MainPID); do
-    if((++attempts > 15)); then
-      echo "[ERROR] reached maximum task execution time"
-      return 4
-    elif [[ $MainPID == 0 ]]; then
-      break;
-    fi
-    sleep 2
-  done
-
-  # Destroy systemd unit state (see manpage for --remain-after-exit flag)
-  systemctl stop -M nsdc ${unit_name} || :
-  return $ExecMainStatus
-}
-
-systemd_run_sync /usr/bin/bash ${tmp_script#${nsdc_prefix}}
+nsdc-run -e -- /usr/bin/bash ${tmp_script#${nsdc_prefix}}
 
 retval=$?
 if [[ $retval == 0 ]]; then

--- a/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
+++ b/root/etc/e-smith/events/actions/nethserver-dc-fixchroot
@@ -27,7 +27,6 @@ if [[ "${provider}" != "ad" ]]; then
     exit 0
 fi
 
-
 for package in bind-utils ntp
 do
     if ! rpm -q --root=${nsroot} $package >/dev/null; then

--- a/root/etc/e-smith/events/actions/nethserver-dc-group-create
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-create
@@ -34,7 +34,7 @@ if(! defined ($groupName)) {
 $groupName =~ s/@.*//;
 
 #Create group 
-system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group add "$groupName"; expect "Added group" { exit 0 }; exit 3'));
+system(qw(nsdc-run -e -- /usr/bin/samba-tool group add), $groupName);
 if ($? != 0) {
     die("[ERROR] Group $groupName creation failed\n");
 }
@@ -42,7 +42,7 @@ if ($? != 0) {
 #Add members to group 
 my $members = join(',', @ARGV);
 if($members) {
-    system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$members"; expect "Added members" { exit 0 }; exit 3'));
+    system(qw(nsdc-run -e -- /usr/bin/samba-tool group addmembers), $groupName, $members);
     if ($? != 0) {
         die("[ERROR] Failed to add members to group $groupName\n");
     }

--- a/root/etc/e-smith/events/actions/nethserver-dc-group-delete
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-delete
@@ -34,7 +34,7 @@ if(! defined ($groupName)) {
 $groupName =~ s/@.*//;
 
 #Delete group 
-system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group delete "$groupName"; expect "Deleted group" { exit 0 }; exit 3'));
+system(qw(nsdc-run -e -- /usr/bin/samba-tool group delete), $groupName);
 
 #die if group output differs from successful output
 if ($? != 0){

--- a/root/etc/e-smith/events/actions/nethserver-dc-group-modify
+++ b/root/etc/e-smith/events/actions/nethserver-dc-group-modify
@@ -34,7 +34,7 @@ my @newmembers = @ARGV;
 my @oldmembers;
 
 #get group users
-open(PS, "expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group listmembers \"$groupName\"; expect { exit 0 }' |");
+open(PS, '-|', qw(nsdc-run -- /usr/bin/samba-tool group listmembers), $groupName);
 while ( <PS> )
 {
     $_ =~  s/^\s+//;;
@@ -67,7 +67,7 @@ foreach my $element (@oldmembers) {
 #remove members
 if (@membersToRemove){
     my $membersToRemove = join (",", @membersToRemove);
-    system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group removemembers "$groupName" "$membersToRemove"; expect "Removed members" { exit 0}; exit 3'));
+    system(qw(nsdc-run -e -- /usr/bin/samba-tool group removemembers), $groupName, $membersToRemove);
     if($? != 0) {
         $errors ++;
     }
@@ -76,7 +76,7 @@ if (@membersToRemove){
 #add members
 if (@membersToAdd){
     my $membersToAdd = join (",", @membersToAdd);
-    system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group addmembers "$groupName" "$membersToAdd"; expect "Added members" { exit 0 }; exit 3'));
+    system(qw(nsdc-run -e -- /usr/bin/samba-tool group addmembers), $groupName, $membersToAdd);
     if($? != 0) {
         $errors ++;
     }

--- a/root/etc/e-smith/events/actions/nethserver-dc-machine-grants
+++ b/root/etc/e-smith/events/actions/nethserver-dc-machine-grants
@@ -30,20 +30,9 @@ fi
 
 sAMAccountName=$(hostname -s | cut --bytes=-15 | tr '[:lower:]' '[:upper:]')\$
 
-expect &>/dev/null <<EOF
-spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group listmembers "Account Operators"
-expect {
-    -nocase -ex "${sAMAccountName}" { exit 0 } 
-    eof { exit 3 }
-}
-EOF
-
+nsdc-run -- /usr/bin/samba-tool group listmembers "Account Operators" | grep -F "${sAMAccountName}"
 if [[ $? == 0 ]]; then
-    expect <<EOF
-spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool group removemembers "Account Operators" "${sAMAccountName}"
-expect "Removed members" { exit 0 }
-exit 3
-EOF
+    nsdc-run -e -- /usr/bin/samba-tool group removemembers "Account Operators" "${sAMAccountName}" | grep -F "Removed members"
     if [[ $? == 0 ]]; then
         echo "[NOTICE] Removed machine account from Account Operators group"
     fi

--- a/root/etc/e-smith/events/actions/nethserver-dc-password-policy
+++ b/root/etc/e-smith/events/actions/nethserver-dc-password-policy
@@ -43,8 +43,6 @@ if($policy) {
     die "[ERROR] No passwordstrength configuration found!\n";
 }
 
-my $scmd = "/usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool";
-
 if ($userName) {
     my $ldapAccount = (split(/@/,$userName))[0];
     my $expiryOpts = '';
@@ -53,7 +51,7 @@ if ($userName) {
     } elsif($PassExpires eq 'yes') {
         $expiryOpts = '--days=' . ($conf{"MaxPassAge"} || '180');
     }
-    system('expect', '-c', qq(spawn -noecho $scmd user setexpiry $ldapAccount $expiryOpts; expect "Expiry for user '$ldapAccount'" { exit 0 }; exit 3));
+    system(qw(nsdc-run -e -- /usr/bin/samba-tool user setexpiry), $ldapAccount, $expiryOpts);
     if ($? != 0) {
         die("[ERROR] Faild to set expiry on user $userName\n");
     }
@@ -66,15 +64,15 @@ if($conf{'PassExpires'} ne 'no') {
     $min = $conf{"MinPassAge"} || '0';
     $max = $conf{"MaxPassAge"} || '180';
 }
-my $domainOpts = qq(--min-pwd-age=$min --max-pwd-age=$max);
+my @domainOpts = ("--min-pwd-age=$min", "--max-pwd-age=$max");
 
 if($conf{'Users'} eq 'strong') {
-    $domainOpts .= qq( --complexity=on --history-length=default);
+    push @domainOpts, qw(--complexity=on --history-length=default);
 } else {
-    $domainOpts .= qq( --complexity=off --history-length=0);
+    push @domainOpts, qw(--complexity=off --history-length=0);
 }
 
-system('expect', '-c', qq(spawn -noecho $scmd domain passwordsettings set $domainOpts; expect "All changes applied successfully!" { exit 0 }; exit 3));
+system(qw(nsdc-run -e -- /usr/bin/samba-tool domain passwordsettings set), @domainOpts);
 if ($? != 0) {
     die("[ERROR] Failed to set domain password policy\n");
 }

--- a/root/etc/e-smith/events/actions/nethserver-dc-password-set
+++ b/root/etc/e-smith/events/actions/nethserver-dc-password-set
@@ -40,30 +40,5 @@ if ! [ -f "${FILE}" ]; then
     exit 1
 fi
 
-exec expect -f - <<EOF
-spawn /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user setpassword "${USER%@${DOMAIN}}"
-log_user 1
-expect {
-    -ex "New Password: " {
-         send -- [read -nonewline [open "${FILE}" r]]
-         send "\n"
-         expect {
-            "Changed password OK" {
-               exit 0
-            }
-            -ex "Retype Password: " {
-                send -- [read -nonewline [open "${FILE}" r]]
-                send "\n"
-                expect {
-                    "Changed password OK" {
-                        exit 0
-                    }
-                }
-            }
-            timeout {exit 3}
-            eof {exit 2}
-         }
-    }
-}
-EOF
+nsdc-run -e -- /usr/bin/samba-tool user setpassword "${USER%@${DOMAIN}}" "--newpassword=$(<${FILE})"
 

--- a/root/etc/e-smith/events/actions/nethserver-dc-pre-backup
+++ b/root/etc/e-smith/events/actions/nethserver-dc-pre-backup
@@ -19,20 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
 #
-ERROR=0
-for DB in $(find /var/lib/machines/nsdc/var/lib/samba/ -name "*.[t,l]db"); do
-    if [[ "${DB#/var/lib/machines/nsdc}" == "/var/lib/samba/private/netlogon_creds_cli.tdb" ]]; then
-        continue;
-    fi
-    expect -f - > /dev/null <<EOF
-        spawn /usr/bin/systemd-run -M nsdc -t -q /usr/bin/tdbbackup "${DB#/var/lib/machines/nsdc}"
-        expect {
-           eof { exit 0 }
-        }
-EOF
-    if [ ! -f ${DB}.bak ]; then
-        echo "Error while backing up ${DB}!"
-        ERROR=1
-    fi
-done
-exit $ERROR
+
+cd /var/lib/machines/nsdc/
+nsdc-run -e -- tdbbackup $(find var/lib/samba/ -name "*.[t,l]db" | sed -e '\|^var/lib/samba/private/netlogon_creds_cli.tdb$| d ; s/^/\//')

--- a/root/etc/e-smith/events/actions/nethserver-dc-provision
+++ b/root/etc/e-smith/events/actions/nethserver-dc-provision
@@ -22,7 +22,8 @@
 
 nsroot=/var/lib/machines/nsdc
 
-systemctl --root=${nsroot} enable samba-provision.service samba.service ntpd.service
+systemctl --root=${nsroot} enable samba-provision.service samba.service ntpd.service nsdc-run.socket
+cp -af /usr/libexec/nethserver/nsdc-run-worker ${nsroot}/usr/libexec/nsdc-run-worker
 
 ProvisionType=$(/sbin/e-smith/config getprop nsdc ProvisionType)
 

--- a/root/etc/e-smith/events/actions/nethserver-dc-set-upn
+++ b/root/etc/e-smith/events/actions/nethserver-dc-set-upn
@@ -35,7 +35,7 @@ replace: uPNSuffixes
 uPNSuffixes: ${Domain}
 " > ${tmp_ldif}
 
-systemd-run -M nsdc -q -t /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb ${tmp_ldif#${nsdc_prefix}} | \
+nsdc-run -- /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb ${tmp_ldif#${nsdc_prefix}} | \
     grep -q -F 'Modified 1 records successfully'
 if [[ $? != 0 ]]; then
     echo "[ERROR] UPN suffix update failed"

--- a/root/etc/e-smith/events/actions/nethserver-dc-sync-upn
+++ b/root/etc/e-smith/events/actions/nethserver-dc-sync-upn
@@ -83,7 +83,7 @@ sub _cb_fix_upn
 $ldif->done();
 close($tmpLdif);
 
-my $out = qx(systemd-run -M nsdc -q -t /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb $tmpLdifNsdc);
+my $out = qx(nsdc-run -- /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb $tmpLdifNsdc);
 if($? != 0) {
     warn "[ERROR] failed to modify UPN suffixes\n";
     $errors ++;

--- a/root/etc/e-smith/events/actions/nethserver-dc-upgrade
+++ b/root/etc/e-smith/events/actions/nethserver-dc-upgrade
@@ -45,3 +45,7 @@ cp -vfp ${nsroot}/var/lib/samba/private/krb5.conf ${nsroot}/etc/krb5.conf
 
 # Restart the Samba DC service in nsdc container
 systemctl -M nsdc restart samba
+
+# Enable and start nsdc-run.socket
+systemctl -M nsdc enable --now nsdc-run.socket
+cp -af /usr/libexec/nethserver/nsdc-run-worker ${nsroot}/usr/libexec/nsdc-run-worker

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-create
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-create
@@ -48,7 +48,7 @@ if ($FullName eq '') {
 $userName =~ s/@.*//;
 
 #Create user
-system('expect', '-c', qq(spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user create "$userName" --random-password --must-change-at-next-login "--login-shell=$shell" "--unix-home=$homeDirPrefix$userName" "--given-name=$FullName" --use-username-as-cn; expect "User '$userName' created successfully" { exit 0 }; exit 3));
+system(qw(nsdc-run -e -- /usr/bin/samba-tool user create), $userName, '--random-password', '--must-change-at-next-login', "--login-shell=$shell", "--unix-home=${homeDirPrefix}${userName}", "--given-name=$FullName", '--use-username-as-cn');
 if ($? != 0) {
     die("[ERROR] User $userName creation failed\n");
 }

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-delete
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-delete
@@ -34,7 +34,7 @@ if(! defined ($userName)) {
 $userName =~ s/@.*//;
 
 #Delete user
-system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user delete "$userName"; expect "Deleted user $userName" { exit 0 }; exit 3'));
+system(qw(nsdc-run -e -- /usr/bin/samba-tool user delete), $userName);
 if ($? != 0) {
     die("[ERROR] User $userName deletion failed\n");
 }

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-lock
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-lock
@@ -34,11 +34,4 @@ if ! [[ $USER == *"@${DOMAIN}" ]]; then
     exit 0
 fi
 
-exec expect -f - <<EOF
-spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user disable "${USER%@${DOMAIN}}"
-expect {
-    "ERROR" {exit 1}
-    eof {exit 0}
-}
-exit 2
-EOF
+exec nsdc-run -e -- /usr/bin/samba-tool user disable "${USER%@${DOMAIN}}"

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-modify
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-modify
@@ -37,7 +37,7 @@ if(! defined ($userName)) {
 $userName =~ s/@.*//;
 
 #Modify user FullName
-system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/pdbedit -u "$userName" "--fullname=$FullName"; expect "Unix username:" { exit 0 }; exit 3' >/dev/null));
+system(qw(nsdc-run -e -- /usr/bin/pdbedit -u), $userName, "--fullname=$FullName");
 if ($? != 0) {
     die("[ERROR] User $userName modification failed\n");
 }
@@ -49,7 +49,7 @@ my $fileFullPath = File::Temp->new(
 );
 
 #retrieve the dn from samaccountname
-my $dn = qx(systemd-run -M nsdc -q -t /usr/bin/ldbsearch -H /var/lib/samba/private/sam.ldb "samaccountname=$userName" dn | sed -n '/^dn: / { s/\r// ; p ; q }');
+my $dn = qx(nsdc-run -- /usr/bin/ldbsearch -H /var/lib/samba/private/sam.ldb "samaccountname=$userName" dn | sed -n '/^dn: / { s/\r// ; p ; q }');
 chomp $dn;
 
 #print the content
@@ -67,9 +67,7 @@ my $fileRelativePath = $fileFullPath;
 $fileRelativePath =~ s|/var/lib/machines/nsdc||;
 
 #modif the samba LDAP
-system(qq(expect -c 'spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/ldbmodify -H /var/lib/samba/private/sam.ldb $fileRelativePath;
-    expect "Modified 1 records successfully" { exit 0 }; exit 3' >/dev/null));
-
+system(qw(nsdc-run -- /usr/bin/ldbmodify -H /var/lib/samba/private/sam.ldb), $fileRelativePath);
 if ($? != 0) {
     die("[ERROR] User $userName shell modification failed\n");
 }

--- a/root/etc/e-smith/events/actions/nethserver-dc-user-unlock
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-unlock
@@ -34,12 +34,4 @@ if ! [[ $USER == *"@${DOMAIN}" ]]; then
     exit 0
 fi
 
-exec expect -f - <<EOF
-spawn -noecho /usr/bin/systemd-run -M nsdc -q -t /usr/bin/samba-tool user enable "${USER%@${DOMAIN}}"
-expect {
-    "Enabled user" {exit 0}
-}
-exit 2
-EOF
-
-
+exec nsdc-run -e -- /usr/bin/samba-tool user enable "${USER%@${DOMAIN}}"

--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/nsdc-run.socket/10base
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/nsdc-run.socket/10base
@@ -1,0 +1,11 @@
+[Unit]
+Description=NSDC container remote command server
+Documentation=https://github.com/NethServer/nethserver-dc/blob/master/README.rst
+
+[Socket]
+Accept=true
+SocketMode=0600
+ListenStream=/var/lib/misc/nsdc-run.sock
+
+[Install]
+WantedBy=sockets.target

--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/nsdc-run@.service/10base
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/nsdc-run@.service/10base
@@ -1,0 +1,6 @@
+[Unit]
+Description=nsdc-run worker process
+Documentation=https://github.com/NethServer/nethserver-dc/blob/master/README.rst
+
+[Service]
+ExecStart=/usr/libexec/nsdc-run-worker

--- a/root/usr/bin/nsdc-run
+++ b/root/usr/bin/nsdc-run
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import sys
+import socket
+import struct
+import argparse
+
+ap = argparse.ArgumentParser(
+    description = "Run the given command remotely, in NSDC container",
+    usage = "%(prog)s [-e] <cmd> [arg...]",
+)
+ap.add_argument('cmd', nargs='+', help='the path to an executable command in NSDC filesystem')
+ap.add_argument('-e', '--capture-stderr', action='store_true', help='grab the command stderr too')
+args = ap.parse_args()
+
+so = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+so.connect('/var/lib/machines/nsdc/var/lib/misc/nsdc-run.sock')
+
+#
+# 1. Prepare and send a message composed by the size header and the payload
+#    The size header is a four bytes binary integer in BE (network) form
+#
+payload = json.dumps({ 'cmd': args.cmd, 'stderr': args.capture_stderr })
+payload_sz = struct.pack('>I', len(payload))
+so.sendall(payload_sz + payload)
+
+#
+# 2. Receive the response message. The last byte transferred represents the
+#    remote command exit code
+#
+buf_sz = 4096
+last_char = ''
+while True:
+    buf = so.recv(buf_sz)
+    if not buf:
+        break
+
+    sys.stdout.write(last_char + buf[:-1])
+    last_char = buf[-1]
+
+if(last_char):
+    sys.exit(ord(last_char))
+else:
+    sys.stderr.write("[ERROR] nsdc-cmd failed to communicate with server\n")
+    sys.exit(253)

--- a/root/usr/libexec/nethserver/nsdc-run-worker
+++ b/root/usr/libexec/nethserver/nsdc-run-worker
@@ -1,0 +1,79 @@
+#!/usr/bin/python -u
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# This python script runs with "-u" (unbuffered i/o) flag!
+
+import sys
+import socket
+import struct
+import json
+import subprocess
+import os
+
+#
+# recvall -- Receive exactly "btr" (bytes-to-read) from socket "so"
+#
+def recvall(so, btr):
+    buf = ''
+    while btr > 0:
+        chunk = so.recv(min(btr, 4096))
+        btr -= len(chunk)
+        buf += chunk
+    return buf
+
+# systemd always passes the socket as fd 3
+so = socket.fromfd(3, socket.AF_UNIX, socket.SOCK_STREAM)
+os.close(3)
+
+#
+# 1. read a message from the socket. The message has a four bytes header
+#    representing the payload size. The message itself is a JSON string 
+#    representing the command to run and its arguments.
+#
+payload_sz = struct.unpack('>I', recvall(so, struct.calcsize('>I')))[0]
+payload = recvall(so, payload_sz)
+args = json.loads(payload)
+
+#
+# 2. spawn the command as a child process. Consume its output by forwarding
+#    it to the socket client.
+#
+try:
+    capture_stderr = None if not args['stderr'] else subprocess.STDOUT
+    child = subprocess.Popen(args['cmd'], stdin=None, stdout=subprocess.PIPE, stderr=capture_stderr)
+
+    while True:
+        data = child.stdout.read()
+        so.sendall(data)
+        if not data:
+            break
+
+    child_exit = child.wait()
+
+except Exception as e:
+    sys.stderr.write("[ERROR] the command '%s' failed: %s" % (args['cmd'][0], e))
+    child_exit = 254
+
+#
+# 3. at the end, send the command exit code to the socket client
+#
+so.sendall(chr(child_exit))

--- a/root/usr/libexec/nethserver/nsdc-run-worker
+++ b/root/usr/libexec/nethserver/nsdc-run-worker
@@ -59,7 +59,9 @@ args = json.loads(payload)
 #
 try:
     capture_stderr = None if not args['stderr'] else subprocess.STDOUT
-    child = subprocess.Popen(args['cmd'], stdin=None, stdout=subprocess.PIPE, stderr=capture_stderr)
+    # Convert unicode strings to plain strings, for execv()
+    encoded_cmd_array = map(lambda x: x.encode('utf-8'), args['cmd'])
+    child = subprocess.Popen(encoded_cmd_array, stdin=None, stdout=subprocess.PIPE, stderr=capture_stderr)
 
     while True:
         data = child.stdout.read()


### PR DESCRIPTION
The nsdc-run command

- runs a command remotely through a Unix stream socket
- catches the command exit code and return it to the caller

The container endpoint runs under systemd socket activation and is
enabled during NSDC installation and upgrade.

NethServer/dev#5544