### PR TITLE
Bump ns-samba 4.7.10

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-a98c475aecdfb1fddf6258075fe5c973065afd06  ns-samba-4.7.8-1.ns7.x86_64.rpm
+540d19335adba3b4a534e502e62d28d604d86a87  ns-samba-4.7.10-1.ns7.x86_64.rpm

--- a/nethserver-dc.spec
+++ b/nethserver-dc.spec
@@ -6,7 +6,7 @@ Summary:        NethServer Domain Controller configuration
 License:        GPLv3+
 URL: %{url_prefix}/%{name}
 Source0:        %{name}-%{version}.tar.gz
-Source1:        https://github.com/NethServer/ns-samba/releases/download/4.7.8/ns-samba-4.7.8-1.ns7.x86_64.rpm
+Source1:        https://github.com/NethServer/ns-samba/releases/download/4.7.10/ns-samba-4.7.10-1.ns7.x86_64.rpm
 
 BuildRequires:  nethserver-devtools
 BuildRequires:  systemd


### PR DESCRIPTION
We're two releases behind upstream

Release notes

- https://www.samba.org/samba/history/samba-4.7.9.html (CVEs)
- https://www.samba.org/samba/history/samba-4.7.10.html (Bugfixes)
