### PR TITLE
Start samba-provision after systemd-networkd 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,12 @@ nethserver-dc-save event
     The realm and domain name are set as described in the ``newdomain`` provision 
     type.
 
+  - ``sme8migration``: this provision procedure is driven by
+    ``nethserver-dc-migrate`` action. It requires a running NSDC, provisioned as
+    ``newdomain``. It copies Samba 3 files from the migration source directory
+    to the NSDC chroot, then restarts the ``samba-provision`` and ``samba``
+    services in the running NSDC container.
+
 * it creates a network bridge if needed, or select an existing one and save it in nsdc bridge db prop (`nethserver-dc-create-bridge` action)
 
 * it waits for the machine to come up (`nethserver-dc-waitstart`)

--- a/createlinks
+++ b/createlinks
@@ -67,7 +67,7 @@ my @templates = (qw(
 event_templates('nethserver-dc-save', @templates);
 
 event_services('nethserver-dc-save', qw(
-   nsdc restart
+   nsdc reload
    dnsmasq restart
 ));
 

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -96,7 +96,7 @@ mv /var/lib/machines/nsdc/var/lib/samba/private/krb5.conf.ori /var/lib/machines/
 rm -f /var/lib/sss/pubconf/kdcinfo.$domain
 
 # Check the new ip address
-if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddr}" &>/dev/null; then
+if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddress}" &>/dev/null; then
     echo "[WARN] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
 fi
 

--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service/10unit
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/system/samba-provision.service/10unit
@@ -1,6 +1,7 @@
 [Unit]
 Description=Domain controller provisioning
 Before=samba.service
+After=network.target
 ConditionPathExists=!/etc/samba/smb.conf
 ConditionPathExists=!/var/lib/samba/private/krb5.conf
 

--- a/root/usr/lib/systemd/system/nsdc.service
+++ b/root/usr/lib/systemd/system/nsdc.service
@@ -14,6 +14,7 @@ Environment=OPTIONS=
 Environment=BRIDGE=brdef
 EnvironmentFile=-/etc/sysconfig/nsdc
 ExecStart=/usr/bin/systemd-nspawn --quiet --keep-unit --boot --network-bridge=${BRIDGE} --machine=nsdc ${OPTIONS}
+ExecReload=/usr/bin/systemctl -M nsdc restart samba-provision.service samba.service
 KillMode=mixed
 Type=notify
 RestartForceExitStatus=133


### PR DESCRIPTION
- Avoid samba-provision failure during sme8migration procedure by delaying the unit to start after systemd `network.target` has been reached.
- Avoid the NSDC container to be restarted during `nethserver-sssd-save` event, according to #88.
- Fix nethserver-dc-change-ip typo 

https://github.com/NethServer/dev/issues/5603