### PR TITLE
Fix sme8migration provision failure

### DIFF
--- a/root/usr/lib/systemd/system/nsdc.service
+++ b/root/usr/lib/systemd/system/nsdc.service
@@ -14,6 +14,7 @@ Environment=OPTIONS=
 Environment=BRIDGE=brdef
 EnvironmentFile=-/etc/sysconfig/nsdc
 ExecStart=/usr/bin/systemd-nspawn --quiet --keep-unit --boot --network-bridge=${BRIDGE} --machine=nsdc ${OPTIONS}
+ExecReload=/usr/bin/systemctl -M nsdc daemon-reload
 ExecReload=/usr/bin/systemctl -M nsdc restart samba-provision.service samba.service
 KillMode=mixed
 Type=notify


### PR DESCRIPTION
The sme8migration provision procedure fails due to
samba-provision.service template expansion. The new unit definition is
not loaded by NSDC systemd instance:

    Warning: samba-provision.service changed on disk. Run
    'systemctl daemon-reload' to reload units.

The fix forces daemon-reload whenever nsdc unit is reloaded, thus the
templates can be expanded at any time.

The fix is not needed if nsdc is restarted or started for the first
time.

NethServer/nethserver-dc#89
https://github.com/NethServer/dev/issues/5603