### PR TITLE
Fix DC ip change false failure

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -100,6 +100,7 @@ if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddress}" &>/dev/null; then
     echo "[WARN] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
 fi
 
+net cache flush
 if ! net ads testjoin >/dev/null; then
     echo "[ERROR] Join is invalid!"
     exit 1


### PR DESCRIPTION
The action fails due to dirty cache entries. This fix cleans up the `net
ads` cache information to prevent failures.

This PR is not related to NethServer/dev#5730 but is nice to have though