### PR TITLE
Samba 4.9.18

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-c62b51b2762e2b96f633c921cf53b9ca606b89bd  ns-samba-4.9.13-1.ns7.x86_64.rpm
+3263c62210be3250eb75d00b71ac7d0f0d7eb278  ns-samba-4.9.18-1.ns7.x86_64.rpm

--- a/nethserver-dc.spec
+++ b/nethserver-dc.spec
@@ -16,7 +16,7 @@ Summary:        NethServer Domain Controller configuration
 License:        GPLv3+
 URL: %{url_prefix}/%{name}
 Source0:        %{name}-%{version}.tar.gz
-Source1:        https://github.com/NethServer/ns-samba/releases/download/4.9.13/ns-samba-4.9.13-1.ns7.%{source1_arch}.rpm
+Source1:        https://github.com/NethServer/ns-samba/releases/download/4.9.18/ns-samba-4.9.18-1.ns7.%{source1_arch}.rpm
 
 BuildRequires:  nethserver-devtools
 BuildRequires:  systemd


### PR DESCRIPTION
Samba release 4.9.18 for NethServer DC

https://github.com/NethServer/ns-samba/releases/tag/4.9.18

https://github.com/NethServer/dev/issues/6046