### PR TITLE
Start DC after restore --skip-network

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -116,6 +116,7 @@ if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddress}" &>/dev/null; then
     echo "[WARN] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
 fi
 
+systemctl restart dnsmasq
 net cache flush
 if ! net ads testjoin >/dev/null; then
     echo "[ERROR] Join is invalid!"

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -119,8 +119,7 @@ fi
 systemctl restart dnsmasq
 net cache flush
 if ! net ads testjoin >/dev/null; then
-    echo "[ERROR] Join is invalid!"
-    exit 1
+    echo "[WARNING] Join could be invalid!"
 fi
 
 exit 0

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -113,7 +113,7 @@ rm -f /var/lib/sss/pubconf/kdcinfo.$domain
 
 # Check the new ip address
 if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddress}" &>/dev/null; then
-    echo "[WARN] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
+    echo "[WARNING] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
 fi
 
 systemctl restart dnsmasq

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -116,10 +116,9 @@ if ! host -t SRV "_ldap._tcp.${domain}" "${ipaddress}" &>/dev/null; then
     echo "[WARNING] The SRV '_ldap._tcp.${domain}' doesn't match with the new ip address '$ipaddress'"
 fi
 
-systemctl restart dnsmasq
 net cache flush
 if ! net ads testjoin >/dev/null; then
-    echo "[WARNING] Join could be invalid!"
+    echo "[WARNING] Join is invalid!"
 fi
 
 exit 0

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -22,6 +22,7 @@
 
 event=$1
 ipaddress=$2
+nsroot=/var/lib/machines/nsdc
 
 status=$(/sbin/e-smith/config getprop nsdc status)
 bridge=$(/sbin/e-smith/config getprop nsdc bridge)
@@ -72,6 +73,9 @@ done
 # Start nsdc
 ip link delete dev vb-nsdc 2>/dev/null
 systemctl start nsdc
+
+# Ensure the worker script is installed after a restore-config --skip-network
+cp -af /usr/libexec/nethserver/nsdc-run-worker ${nsroot}/usr/libexec/nsdc-run-worker
 
 /etc/e-smith/events/actions/nethserver-dc-waitstart
 

--- a/root/etc/e-smith/events/actions/nethserver-dc-change-ip
+++ b/root/etc/e-smith/events/actions/nethserver-dc-change-ip
@@ -23,6 +23,21 @@
 event=$1
 ipaddress=$2
 
+status=$(/sbin/e-smith/config getprop nsdc status)
+bridge=$(/sbin/e-smith/config getprop nsdc bridge)
+green_ipaddr=$(/sbin/e-smith/db networks getprop $bridge ipaddr)
+green_netmask=$(/sbin/e-smith/db networks getprop $bridge netmask)
+
+if [[ $status != 'enabled' ]]; then
+    echo "[NOTICE] nsdc is disabled"
+    exit 0
+fi
+
+if [[ -z $bridge ]]; then
+    echo "[ERROR] nsdc bridge is not configured"
+    exit 1
+fi
+
 if [ -z $ipaddress ]; then
     echo "[ERROR] No IP address given"
     exit 1
@@ -34,10 +49,6 @@ if systemctl -q is-active nsdc 2>/dev/null; then
 fi
 
 # Check if DC ip is inside the green network
-bridge=$(/sbin/e-smith/config getprop nsdc bridge)
-green_ipaddr=$(/sbin/e-smith/db networks getprop $bridge ipaddr)
-green_netmask=$(/sbin/e-smith/db networks getprop $bridge netmask)
-
 perl -e "use NetAddr::IP; \$n=NetAddr::IP->new('$ipaddress'); \$h=NetAddr::IP->new('$green_ipaddr', '$green_netmask'); exit ! \$n->within(\$h);"
 
 if [ $? -gt 0 ]; then


### PR DESCRIPTION
If network configuration is not restore (by --skip-network flag) the nsdc container is not started.

This PR fixes the `nethserver-dc-change-ip` event to start the nsdc container correctly in that use case. 

See also https://github.com/NethServer/docs/pull/489

https://github.com/NethServer/dev/issues/6099