### PR TITLE
checkpassword. Fix special chars list

### DIFF
--- a/root/var/lib/machines/nsdc/usr/local/sbin/checkpassword.pl
+++ b/root/var/lib/machines/nsdc/usr/local/sbin/checkpassword.pl
@@ -4,7 +4,6 @@
 
 use strict;
 
-my $specialchars='!,@,$,#,%,^,&,*,(,),-,_,+,=';
 my $min_length;
 my $min_uppercase;
 my $min_lowercase;
@@ -58,7 +57,7 @@ foreach my $pass_char (@array_pass)
                 $ctr_digits++;
         }
 	# check special chars
-        elsif($pass_char =~ /[$specialchars]/)
+        elsif($pass_char =~ /[\W_]/)
         {
                 $ctr_specialchar++;
         }


### PR DESCRIPTION
The list of special characters is not the same of password-strength system validator. This fix applies the same special characters list here.

See also password-strength validation action

https://github.com/NethServer/nethserver-base/blob/0f918ffcee8ae6c89cba77975da07d6f127ed284/root/etc/e-smith/validators/actions/password-strength#L60

Original issue: https://github.com/NethServer/dev/issues/6613

Refs  https://github.com/NethServer/dev/issues/6637