### PR TITLE
Fix ldapservice login

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -80,6 +80,7 @@ event_actions('post-restore-config', qw(
     nethserver-dc-network-reset 03
     nethserver-dc-post-restore 40
     nethserver-dc-sysvolreset 80
+    nethserver-dc-ldbfixes 80
 ));
 event_templates('post-restore-config', @templates);
 
@@ -173,6 +174,7 @@ event_templates('nethserver-dc-upgrade', @templates);
 event_actions('nethserver-dc-upgrade', qw(
     nethserver-dc-fixinclude 20
     nethserver-dc-upgrade 30
+    nethserver-dc-ldbfixes 80
 ));
 
 # nethserver-dc-change-ip event

--- a/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
+++ b/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
@@ -73,8 +73,6 @@ fi
 # userWorkstations (since 4.16.5): allow access from any workstation for apps like Webtop
 /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb <<<"\$(get_dn ldapservice)
 changetype: modify
-replace: userWorkstations
--
 replace: userAccountControl
 userAccountControl: 66048
 "

--- a/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
+++ b/root/etc/e-smith/events/actions/nethserver-dc-createldapservice
@@ -69,11 +69,11 @@ if [[ -z "\$(get_dn ldapservice)" ]]; then
   || ((++errors))
 fi
 
-# set password never expires and deny access from any workstation:
+# userAccountControl: set password never expires
+# userWorkstations (since 4.16.5): allow access from any workstation for apps like Webtop
 /usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb <<<"\$(get_dn ldapservice)
 changetype: modify
 replace: userWorkstations
-userWorkstations: /
 -
 replace: userAccountControl
 userAccountControl: 66048

--- a/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
+++ b/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2017 Nethesis S.r.l.
+# Copyright (C) 2022 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.

--- a/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
+++ b/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+nsroot=/var/lib/machines/nsdc
+
+nsdc-run -e -- /usr/bin/bash -c '
+function get_dn()
+{
+  /usr/bin/ldbsearch -H /var/lib/samba/private/sam.ldb "sAMAccountName=$1" dn | \
+    sed -n "/^dn: / { s/\r// ; p ; q }"
+}
+
+DN=$(get_dn ldapservice)
+
+/usr/bin/ldbmodify -v -i -H /var/lib/samba/private/sam.ldb <<EOF
+${DN}
+changetype: modify
+replace: userWorkstations
+EOF
+'
+
+exit 0

--- a/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
+++ b/root/etc/e-smith/events/actions/nethserver-dc-ldbfixes
@@ -20,8 +20,7 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-nsroot=/var/lib/machines/nsdc
-
+# shellcheck disable=SC1004,SC2016
 nsdc-run -e -- /usr/bin/bash -c '
 function get_dn()
 {


### PR DESCRIPTION
Since Samba 4.16.5 the userWorkstations attribute must be cleared, otherwise Webtop cannot login as `ldapservice`. Error in webtop.log:

    LDAP: error code 49 - 80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 531, v1db1

The original value `/` was set to forbid logging on workstations interactively with `ldapservice` credentials. Now it seems the attribute is honored by LDAP simple binds too.

The changed action runs during the nethserver-dc-update event: it is executed by post-restore-config (in system-adjust), installation and RPM updates.

https://github.com/NethServer/dev/issues/6702