### PR TITLE
Fix user creation regression

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-dc-user-create
+++ b/root/etc/e-smith/events/actions/nethserver-dc-user-create
@@ -47,9 +47,14 @@ if ($FullName eq '') {
 #accept user@domain format
 $userName =~ s/@.*//;
 
-#Create user
-system(qw(nsdc-run -e -- /usr/bin/samba-tool user create), $userName, '--random-password', '--must-change-at-next-login', "--login-shell=$shell", "--unix-home=${homeDirPrefix}${userName}", "--given-name=$FullName", '--use-username-as-cn');
+# Create user
+system(qw(nsdc-run -e -- /usr/bin/samba-tool user create), $userName, '--random-password', '--must-change-at-next-login', "--login-shell=$shell", "--unix-home=${homeDirPrefix}${userName}", '--use-username-as-cn');
 if ($? != 0) {
     die("[ERROR] User $userName creation failed\n");
 }
 
+# Set the full name attribute after creation, to fix #6722
+system(qw(nsdc-run -e -- /usr/bin/pdbedit -u), $userName, "--fullname=$FullName");
+if ($? != 0) {
+    die("[ERROR] Failed to set full name of $userName\n");
+}


### PR DESCRIPTION
Since Samba DC 4.16 upgrade, "samba-tool user create" fails if the "--given-name" option value contains diacritics. As pdbedit still works, change the full name value with it, as the user-modify event already does.

Refs https://github.com/NethServer/dev/issues/6722